### PR TITLE
CI volume permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,21 @@ MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
 ENV TERRAFORM_VERSION 0.7.4
 
+# This is the release of https://github.com/hashicorp/docker-base to pull in order
+# to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.
+ENV DOCKER_BASE_VERSION=0.0.4
+
 RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget unzip && \
     gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
+    wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip" && \
+    wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS" && \
+    wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig" && \
+    gpg --batch --verify docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS.sig docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS && \
+    grep docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip docker-base_${DOCKER_BASE_VERSION}_SHA256SUMS | sha256sum -c && \
+    unzip docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip && \
+    cp bin/gosu /bin && \
     wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
     wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS" && \
     wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS.sig" && \
@@ -17,9 +28,11 @@ RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget
     rm -rf /tmp/build && \
     rm -rf /root/.gnupg
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
 VOLUME ["/data"]
 WORKDIR /data
 
-ENTRYPOINT ["/bin/terraform"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 CMD ["--help"]

--- a/circle.yml
+++ b/circle.yml
@@ -21,17 +21,48 @@ test:
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
                  --rm unifio/terraform plan
     - |
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
                  --rm unifio/terraform apply
     - |
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
                  --rm unifio/terraform destroy -force
+    - "! test -O uat/terraform.tfstate"
+    - rm -f uat/terraform.*
+    - |
+      docker run -v ~/.aws:/home/user/.aws \
+                 -v `pwd`:/data \
+                 -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e LOCAL_USER_ID=$UID \
+                 -e DEBUG=true \
+                 --rm unifio/terraform plan
+    - |
+      docker run -v ~/.aws:/home/user/.aws \
+                 -v `pwd`:/data \
+                 -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e LOCAL_USER_ID=$UID \
+                 -e DEBUG=true \
+                 --rm unifio/terraform apply
+    - |
+      docker run -v ~/.aws:/home/user/.aws \
+                 -v `pwd`:/data \
+                 -w /data/uat \
+                 -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e LOCAL_USER_ID=$UID \
+                 -e DEBUG=true \
+                 --rm unifio/terraform destroy -force
+    - test -O uat/terraform.tfstate
+    
 
 deployment:
   hub:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+## Defaulting to root user (UID 0) to maintain backwards compatibility
+USER_ID=${LOCAL_USER_ID:-0}
+
+if [ "$DEBUG" == true ] ; then
+  echo "Starting with UID: $USER_ID"
+fi
+if [ "$USER_ID" -ne "0" ]; then
+  adduser -s /bin/sh -D -u $USER_ID user
+  export HOME=/home/user
+  exec /bin/gosu user /bin/terraform "$@"
+else
+  exec /bin/terraform "$@"
+fi


### PR DESCRIPTION
Update for specifying the UID of the user that executes Terraform within the container. This is useful for coordinating the user calling the container with the user within the container, so that artifacts remaining in the workspace after the Terraform run are not owned by root. This has been raised as an issue on CI systems where the builds are executed by a non-privileged user and the remaining artifacts cannot be cleaned up.
