### PR TITLE
Updated Terraform Version, Cleaned up Circle file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
-ENV TERRAFORM_VERSION 0.8.2
+ENV TERRAFORM_VERSION 0.8.4
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple file based configuration gives you a single view of your entire infrastru
 
 ## Dockerfile
 
-This Docker image is based on the official [alpine:3.4](https://hub.docker.com/_/alpine/) base image.
+This Docker image is based on the official [alpine:3.5](https://hub.docker.com/_/alpine/) base image.
 
 ## Enhancements
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   environment:
-    TF_VERSION: 0.8.2
+    TF_VERSION: 0.8.4
+    DOCKER_IMAGE: 'unifio/terraform'
   services:
     - docker
 
@@ -10,31 +11,34 @@ dependencies:
   override:
     - docker info
     - if [[ -e ~/docker/image.tar ]]; then docker load --input ~/docker/image.tar; fi
-    - docker build -t unifio/terraform .
+    - docker build --rm=false -t ${DOCKER_IMAGE} .
     - mkdir -p ~/docker
-    - docker save unifio/terraform > ~/docker/image.tar
+    - docker save ${DOCKER_IMAGE} > ~/docker/image.tar
 
 test:
   override:
-    - docker run unifio/terraform version
+    - docker run -e CHECKPOINT_DISABLE=1 ${DOCKER_IMAGE} version
     - |
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
-                 unifio/terraform plan
+                 -e CHECKPOINT_DISABLE=1 \
+                 ${DOCKER_IMAGE} plan
     - |
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
-                 unifio/terraform apply
+                 -e CHECKPOINT_DISABLE=1 \
+                 ${DOCKER_IMAGE} apply
     - |
       docker run -v ~/.aws:/root/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
-                 unifio/terraform destroy -force
+                 -e CHECKPOINT_DISABLE=1 \
+                 ${DOCKER_IMAGE} destroy -force
     - "! test -O uat/terraform.tfstate"
     - rm -f uat/terraform.*
     - |
@@ -42,25 +46,28 @@ test:
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e CHECKPOINT_DISABLE=1 \
                  -e LOCAL_USER_ID=$UID \
                  -e DEBUG=true \
-                 unifio/terraform plan
+                 ${DOCKER_IMAGE} plan
     - |
       docker run -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e CHECKPOINT_DISABLE=1 \
                  -e LOCAL_USER_ID=$UID \
                  -e DEBUG=true \
-                 unifio/terraform apply
+                 ${DOCKER_IMAGE} apply
     - |
       docker run -v ~/.aws:/home/user/.aws \
                  -v `pwd`:/data \
                  -w /data/uat \
                  -e AWS_DEFAULT_REGION=us-east-1 \
+                 -e CHECKPOINT_DISABLE=1 \
                  -e LOCAL_USER_ID=$UID \
                  -e DEBUG=true \
-                 unifio/terraform destroy -force
+                 ${DOCKER_IMAGE} destroy -force
     - test -O uat/terraform.tfstate
 
 
@@ -69,5 +76,5 @@ deployment:
     branch: master
     commands:
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - docker tag -f `docker images | grep -E 'unifio/terraform' | awk '{print $3}'` unifio/terraform:${TF_VERSION}
-      - docker push unifio/terraform
+      - docker tag -f `docker images | grep -E "${DOCKER_IMAGE}" | awk '{print $3}'` ${DOCKER_IMAGE}:${TF_VERSION}
+      - docker push ${DOCKER_IMAGE}


### PR DESCRIPTION
- Updated terraform to version 0.8.4
- Updated Circle.yml file to
   - ignore errors with intermediary containers as [recommended by Circleci](https://circleci.com/docs/docker/#deployment-to-a-docker-registry)
   - use variable DOCKER_IMAGE rather then manually using image name.
   - Added CHECKPOINT_DISABLE to commands to speed up process and avoid un-needed calls to hashicorp version checking.
- Updated README to reflect alpine 3.5 as base image.