### PR TITLE
Update to Terraform 0.9.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
-ENV TERRAFORM_VERSION 0.8.8
+ENV TERRAFORM_VERSION 0.9.2
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    TF_VERSION: 0.8.8
+    TF_VERSION: 0.9.2
     DOCKER_IMAGE: 'unifio/terraform'
   services:
     - docker


### PR DESCRIPTION
Upgrade to Terraform 0.9.2.  This is required for API Gateway to codify usage plans.

https://github.com/hashicorp/terraform/blob/v0.9.2/CHANGELOG.md
