### PR TITLE
v0.9.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
 ENV TERRAFORM_VERSION 0.9.6
@@ -8,7 +8,7 @@ ENV TERRAFORM_VERSION 0.9.6
 ENV DOCKER_BASE_VERSION=0.0.4
 
 RUN apk add --no-cache --update ca-certificates gnupg openssl git mercurial wget unzip && \
-    gpg --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
+    gpg --keyserver keys.gnupg.net --recv-keys 91A6E7F85D05C65630BEF18951852D87348FFC4C && \
     mkdir -p /tmp/build && \
     cd /tmp/build && \
     wget -q "https://releases.hashicorp.com/docker-base/${DOCKER_BASE_VERSION}/docker-base_${DOCKER_BASE_VERSION}_linux_amd64.zip" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 MAINTAINER "Unif.io, Inc. <support@unif.io>"
 
-ENV TERRAFORM_VERSION 0.9.6
+ENV TERRAFORM_VERSION 0.9.8
 
 # This is the release of https://github.com/hashicorp/docker-base to pull in order
 # to provide HashiCorp-built versions of basic utilities like dumb-init and gosu.

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    TF_VERSION: 0.9.6
+    TF_VERSION: 0.9.8
     DOCKER_IMAGE: 'unifio/terraform'
   services:
     - docker


### PR DESCRIPTION
Skipping v0.9.7 as it had a serious regression in it. One tweak to support Alpine 3.6. Anyone know of any other gotchas with 3.6 before we upgrade?